### PR TITLE
誰の出品物かもあわせて登録するように修正した[closes #31]

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -1,4 +1,6 @@
 class ExhibitsController < ApplicationController
+  permits :title, :description, :type
+
   def index
     @lts   = LightningTalk.all
     @foods = Food.all
@@ -10,8 +12,8 @@ class ExhibitsController < ApplicationController
     @exhibit  = Exhibit.new
   end
 
-  def create
-    @exhibit = Exhibit.new(exhibit_params)
+  def create(exhibit)
+    @exhibit = Exhibit.new(exhibit.merge(user: current_user))
 
     if @exhibit.save
       @exhibit = @exhibit.becomes(Exhibit)
@@ -24,11 +26,5 @@ class ExhibitsController < ApplicationController
 
   def show(id)
     @exhibit = Exhibit.find(id)
-  end
-
-  private
-
-  def exhibit_params
-    params.require(:exhibit).permit(:title, :description, :type)
   end
 end

--- a/db/migrate/20150627035953_change_exhibits_user_id_column.rb
+++ b/db/migrate/20150627035953_change_exhibits_user_id_column.rb
@@ -1,0 +1,16 @@
+class ChangeExhibitsUserIdColumn < ActiveRecord::Migration
+  class Exhibit < ActiveRecord::Base; end
+  class User < ActiveRecord::Base; end
+
+  def change
+    reversible do |dir|
+      dir.up do
+        Exhibit.all.each do |exhibit|
+          exhibit.update_attribute(:user_id, User.first.id)
+        end
+      end
+    end
+
+    change_column :exhibits, :user_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150621170956) do
+ActiveRecord::Schema.define(version: 20150627035953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20150621170956) do
     t.string   "title",       null: false
     t.text     "description"
     t.string   "type",        null: false
-    t.integer  "user_id"
+    t.integer  "user_id",     null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end


### PR DESCRIPTION
## 概要
出品物を登録する際に「誰の出品物なのか」を記録しなくても登録完了してしまっていたので、「誰の出品物なのか」を登録するように修正した（登録されていない場合...システム的にありえないが...のときは、エラーが出るようにした）。

## 対応ストーリー
This work connects to #31 
